### PR TITLE
Update Ingress to use networking.k8s.io/v1 API Version

### DIFF
--- a/charts/allure-ee/templates/_helpers.tpl
+++ b/charts/allure-ee/templates/_helpers.tpl
@@ -22,6 +22,48 @@ Create chart name and version as used by the chart label.
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+
+{{/*
+Get KubeVersion removing pre-release information.
+*/}}
+{{- define "allure-ee.kubeVersion" -}}
+  {{- default .Capabilities.KubeVersion.Version (regexFind "v[0-9]+\\.[0-9]+\\.[0-9]+" .Capabilities.KubeVersion.Version) -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for ingress.
+*/}}
+{{- define "allure-ee.ingress.apiVersion" -}}
+  {{- if and (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (semverCompare ">= 1.19.x" (include "allure-ee.kubeVersion" .)) -}}
+      {{- print "networking.k8s.io/v1" -}}
+  {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Return if ingress is stable.
+*/}}
+{{- define "allure-ee.ingress.isStable" -}}
+  {{- eq (include "allure-ee.ingress.apiVersion" .) "networking.k8s.io/v1" -}}
+{{- end -}}
+
+{{/*
+Return if ingress supports ingressClassName.
+*/}}
+{{- define "allure-ee.ingress.supportsIngressClassName" -}}
+  {{- or (eq (include "allure-ee.ingress.isStable" .) "true") (and (eq (include "allure-ee.ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18.x" (include "allure-ee.kubeVersion" .))) -}}
+{{- end -}}
+
+{{/*
+Return if ingress supports pathType.
+*/}}
+{{- define "allure-ee.ingress.supportsPathType" -}}
+  {{- or (eq (include "allure-ee.ingress.isStable" .) "true") (and (eq (include "allure-ee.ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18.x" (include "allure-ee.kubeVersion" .))) -}}
+{{- end -}}
+
 {{/*
 Create a default fully qualified gateway name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).

--- a/charts/allure-ee/templates/ingress.yaml
+++ b/charts/allure-ee/templates/ingress.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.ingress.host }}
-apiVersion: extensions/v1beta1
+{{- $ingressApiIsStable := eq (include "allure-ee.ingress.isStable" .) "true" -}}
+{{- $ingressSupportsIngressClassName := eq (include "allure-ee.ingress.supportsIngressClassName" .) "true" -}}
+{{- $ingressSupportsPathType := eq (include "allure-ee.ingress.supportsPathType" .) "true" -}}
+{{- $ingressPathType := .Values.ingress.pathType | default "ImplementationSpecific" -}}
+apiVersion: {{ include "allure-ee.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ template "allure-ee.fullname" . }}
@@ -13,14 +17,31 @@ metadata:
 {{ toYaml .Values.ingress.annotations | indent 4 }}
 {{- end }}
 spec:
+  {{- if and $ingressSupportsIngressClassName .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
+  {{- end }}
   rules:
   - host: {{ .Values.ingress.host | quote }}
     http:
       paths:
       - path: /
+        {{- if $ingressSupportsPathType }}
+        pathType: {{ $ingressPathType }}
+        {{- end }}
         backend:
+          {{- if $ingressApiIsStable }}
+          service:
+            name: {{ template "allure-ee.gateway.fullname" . }}
+            port:
+              {{- if kindIs "float64" .Values.gateway.service.port }}
+              number: {{ .Values.gateway.service.port }}
+              {{- else }}
+              name: {{ .Values.gateway.service.port }}
+              {{- end }}
+          {{- else }}
           serviceName: {{ template "allure-ee.gateway.fullname" . }}
           servicePort: {{ .Values.gateway.service.port }}
+          {{- end }}
 {{- if .Values.ingress.tls }}
   tls:
 {{ toYaml .Values.ingress.tls | indent 4 }}

--- a/charts/allure-ee/values.yaml
+++ b/charts/allure-ee/values.yaml
@@ -17,9 +17,9 @@ strategy:
 ingress:
 #  host: allure.local
   annotations:
-    kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/ssl-redirect: "false"
-    nginx.ingress.kubernetes.io/proxy-body-size: "50m"
+    # kubernetes.io/ingress.class: nginx
+    # nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    # nginx.ingress.kubernetes.io/proxy-body-size: "50m"
   tls:
   # - secretName: allure.local
   #   hosts:


### PR DESCRIPTION
Improve ingress template to add support for new ingress features added in Kubernetes 1.18 and 1.19:

`networking.k8s.io/v1` support
`ingressClassName` field support
`pathType` field support